### PR TITLE
Add manual workflow to build & publish binary to HF bucket

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Build & publish binary
+
+# Manually triggered. Builds sbx-server from the latest main branch and publishes
+# it to the `huggingface/sbx-server` bucket twice:
+#   1. sbx-server-<commit>  -> immutable, commit-labelled history
+#   2. sbx-server           -> the default file downstream users consume
+# The second upload is a server-side remote copy (no re-upload).
+#
+# Auth uses Trusted Publishers (OIDC) — no HF_TOKEN secret to store/rotate.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write # required so the job can mint an OIDC token for the HF exchange
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      TARGET: x86_64-unknown-linux-musl
+      BUCKET: hf://buckets/huggingface/sbx-server
+      # The HF resource the minted OIDC token is scoped to. The `hf` CLI detects
+      # GitHub Actions and performs the token exchange automatically.
+      HF_OIDC_RESOURCE: buckets/huggingface/sbx-server
+
+    steps:
+      - name: Check out latest main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Resolve commit hash
+        id: vars
+        run: echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build static musl binary
+        run: |
+          rustup target add "$TARGET"
+          cargo build --release --target "$TARGET"
+
+      - name: Install the hf CLI
+        run: |
+          curl -LsSf https://hf.co/cli/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Upload commit-labelled binary
+        run: |
+          hf cp \
+            "target/$TARGET/release/sbx-server" \
+            "$BUCKET/sbx-server-${{ steps.vars.outputs.commit }}"
+
+      - name: Update default binary (server-side copy)
+        run: |
+          hf cp \
+            "$BUCKET/sbx-server-${{ steps.vars.outputs.commit }}" \
+            "$BUCKET/sbx-server"


### PR DESCRIPTION
## What

Adds `.github/workflows/publish.yml` — a manually-triggered (`workflow_dispatch`) workflow that automates building the `sbx-server` binary from the latest `main` and publishing it to the [`huggingface/sbx-server` bucket](https://huggingface.co/buckets/huggingface/sbx-server).

## How

1. Checks out `main` and resolves the short commit hash.
2. Builds the static `x86_64-unknown-linux-musl` binary (`cargo build --release`).
3. Uploads twice via `hf cp`:
   - `sbx-server-<commit>` — immutable, commit-labelled history copy.
   - `sbx-server` — the default file downstream users consume, written as a **server-side remote copy** (no re-upload).

## Auth

Uses [Trusted Publishers](https://huggingface.co/docs/hub/en/trusted-publishers) (OIDC) scoped to the bucket via `HF_OIDC_RESOURCE` + `id-token: write` — no `HF_TOKEN` secret to store or rotate. The trusted publisher (provider: GitHub Actions, `repository=Wauplin/sandbox-server`, `branch=main`, `workflow=publish.yml`) has been configured on the bucket settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)