### PR TITLE
refactor: dedup and simplify HTTP/exec/files handlers

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -16,6 +16,8 @@ use crate::{now_ms, State};
 
 /// Heartbeat interval for long-silent streams, to keep the proxy connection alive.
 const PING_INTERVAL: Duration = Duration::from_secs(15);
+/// Keepalive frame written on stream timeout (kept identical across all streams).
+const PING_CHUNK: &[u8] = b"{\"event\":\"ping\"}\n";
 /// Per-process buffered log budget for background processes.
 const LOG_BUFFER_BYTES: usize = 4 * 1024 * 1024;
 
@@ -36,20 +38,20 @@ pub struct ExitInfo {
 
 impl Event {
     fn to_line(&self) -> String {
-        match self {
-            Event::Stdout(d) => format!("{}\n", serde_json::json!({"event": "stdout", "data": d})),
-            Event::Stderr(d) => format!("{}\n", serde_json::json!({"event": "stderr", "data": d})),
-            Event::Exit(info) => format!(
-                "{}\n",
-                serde_json::json!({
-                    "event": "exit",
-                    "exit_code": info.exit_code,
-                    "signal": info.signal,
-                    "timed_out": info.timed_out,
-                    "duration_ms": info.duration_ms,
-                })
-            ),
-        }
+        let mut line = match self {
+            Event::Stdout(d) => serde_json::json!({"event": "stdout", "data": d}).to_string(),
+            Event::Stderr(d) => serde_json::json!({"event": "stderr", "data": d}).to_string(),
+            Event::Exit(info) => serde_json::json!({
+                "event": "exit",
+                "exit_code": info.exit_code,
+                "signal": info.signal,
+                "timed_out": info.timed_out,
+                "duration_ms": info.duration_ms,
+            })
+            .to_string(),
+        };
+        line.push('\n');
+        line
     }
 
     fn byte_len(&self) -> usize {
@@ -99,19 +101,10 @@ impl ExecSpec {
             (Some(false), _) => return Err("shell=false requires 'cmd' to be an array of strings".into()),
             (None, _) => return Err("missing 'cmd' (string or array of strings)".into()),
         };
-        let env = body
-            .get("env")
-            .and_then(|v| v.as_object())
-            .map(|m| {
-                m.iter()
-                    .map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_string()))
-                    .collect()
-            })
-            .unwrap_or_default();
         Ok(ExecSpec {
             argv,
             display,
-            env,
+            env: crate::json_string_map(body, "env"),
             cwd: body.get("cwd").and_then(|v| v.as_str()).map(String::from),
             timeout_secs: body.get("timeout").and_then(|v| v.as_f64()),
             stdin: body.get("stdin").and_then(|v| v.as_str()).map(String::from),
@@ -356,6 +349,22 @@ fn pump_background(proc: Arc<Proc>, rx: Receiver<Event>) {
 // HTTP handlers
 // ---------------------------------------------------------------------------
 
+/// Look up a process by its (string) pid, replying 404 if it doesn't exist.
+/// `Ok(None)` means the 404 was already written and the caller should return.
+fn require_proc(
+    state: &Arc<State>,
+    pid: &str,
+    resp: &mut ResponseWriter,
+) -> std::io::Result<Option<Arc<Proc>>> {
+    match pid.parse().ok().and_then(|pid| state.procs.get(pid)) {
+        Some(proc) => Ok(Some(proc)),
+        None => {
+            resp.error(404, &format!("no such process: {pid}"))?;
+            Ok(None)
+        }
+    }
+}
+
 /// Streams events from `rx` as NDJSON chunks until Exit, with keepalive pings.
 fn stream_events(rx: &Receiver<Event>, resp: &mut ResponseWriter) -> std::io::Result<()> {
     loop {
@@ -368,7 +377,7 @@ fn stream_events(rx: &Receiver<Event>, resp: &mut ResponseWriter) -> std::io::Re
                 }
             }
             Err(RecvTimeoutError::Timeout) => {
-                resp.chunk(b"{\"event\":\"ping\"}\n")?;
+                resp.chunk(PING_CHUNK)?;
             }
             Err(RecvTimeoutError::Disconnected) => return Ok(()),
         }
@@ -441,16 +450,14 @@ pub fn handle_logs(
     params: &HashMap<String, String>,
     resp: &mut ResponseWriter,
 ) -> std::io::Result<()> {
-    let Some(proc) = pid.parse().ok().and_then(|pid| state.procs.get(pid)) else {
-        return resp.error(404, &format!("no such process: {pid}"));
-    };
-    let follow = params.get("follow").map(|v| v == "true" || v == "1").unwrap_or(false);
+    let Some(proc) = require_proc(state, pid, resp)? else { return Ok(()) };
+    let follow = crate::http::bool_param(params, "follow", false);
 
     resp.start_stream(200, "application/x-ndjson")?;
 
     // Snapshot buffered events and (if following) subscribe atomically, so no
     // event is missed or duplicated between replay and live streaming.
-    let (snapshot, rx, exited) = {
+    let (snapshot, rx) = {
         let mut proc_state = proc.state.lock().unwrap();
         let snapshot: Vec<Event> = proc_state.events.iter().cloned().collect();
         let exited = proc_state.exit.is_some();
@@ -461,24 +468,22 @@ pub fn handle_logs(
         } else {
             None
         };
-        (snapshot, rx, exited)
+        (snapshot, rx)
     };
 
     for event in &snapshot {
         resp.chunk(event.to_line().as_bytes())?;
     }
+    // If the proc exited between lookup and subscribe, `rx` is None and the
+    // snapshot above already carried the Exit event — nothing left to stream.
     if let Some(rx) = rx {
         stream_events(&rx, resp)?;
-    } else if !exited && follow {
-        // raced: proc exited between lookup and subscribe — snapshot already has Exit
     }
     Ok(())
 }
 
 pub fn handle_wait(state: &Arc<State>, pid: &str, resp: &mut ResponseWriter) -> std::io::Result<()> {
-    let Some(proc) = pid.parse().ok().and_then(|pid| state.procs.get(pid)) else {
-        return resp.error(404, &format!("no such process: {pid}"));
-    };
+    let Some(proc) = require_proc(state, pid, resp)? else { return Ok(()) };
     resp.start_stream(200, "application/x-ndjson")?;
     let mut guard = proc.state.lock().unwrap();
     loop {
@@ -506,9 +511,7 @@ pub fn handle_kill(
 ) -> std::io::Result<()> {
     let body = read_body(request, reader, 1024 * 1024)?;
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap_or(serde_json::json!({}));
-    let Some(proc) = pid.parse().ok().and_then(|pid| state.procs.get(pid)) else {
-        return resp.error(404, &format!("no such process: {pid}"));
-    };
+    let Some(proc) = require_proc(state, pid, resp)? else { return Ok(()) };
     let signal = match json.get("signal") {
         Some(serde_json::Value::String(s)) => match s.to_uppercase().as_str() {
             "TERM" | "SIGTERM" => libc::SIGTERM,
@@ -531,10 +534,8 @@ pub fn handle_stdin(
     pid: &str,
     resp: &mut ResponseWriter,
 ) -> std::io::Result<()> {
-    let Some(proc) = pid.parse().ok().and_then(|pid| state.procs.get(pid)) else {
-        return resp.error(404, &format!("no such process: {pid}"));
-    };
-    let eof = request.params.get("eof").map(|v| v == "true" || v == "1").unwrap_or(false);
+    let Some(proc) = require_proc(state, pid, resp)? else { return Ok(()) };
+    let eof = crate::http::bool_param(&request.params, "eof", false);
     let mut stdin_guard = proc.stdin.lock().unwrap();
     let Some(stdin) = stdin_guard.as_mut() else {
         return resp.error(409, "stdin not available for this process");

--- a/src/files.rs
+++ b/src/files.rs
@@ -17,15 +17,18 @@ fn require_path(
     request: &Request,
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
-) -> Result<String, std::io::Result<()>> {
+) -> std::io::Result<Option<String>> {
     let raw = match request.params.get("path").map(|s| s.as_str()) {
         Some(p) if !p.is_empty() => p,
-        _ => return Err(resp.error(400, "missing 'path' query parameter")),
+        _ => {
+            resp.error(400, "missing 'path' query parameter")?;
+            return Ok(None);
+        }
     };
-    match sandbox {
-        None => Ok(raw.to_string()),
-        Some(sbx) => Ok(crate::sandboxes::resolve_in_home(&sbx.home, raw).to_string_lossy().into_owned()),
-    }
+    Ok(Some(match sandbox {
+        None => raw.to_string(),
+        Some(sbx) => crate::sandboxes::resolve_in_home(&sbx.home, raw).to_string_lossy().into_owned(),
+    }))
 }
 
 pub fn handle_read(
@@ -33,10 +36,7 @@ pub fn handle_read(
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
 ) -> std::io::Result<()> {
-    let path = match require_path(request, resp, sandbox) {
-        Ok(p) => p,
-        Err(r) => return r,
-    };
+    let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
     let path = path.as_str();
     let mut file = match fs::File::open(path) {
         Ok(f) => f,
@@ -82,11 +82,8 @@ pub fn handle_write(
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
 ) -> std::io::Result<()> {
-    let path = match require_path(request, resp, sandbox) {
-        Ok(p) => p,
-        Err(r) => return r,
-    };
-    let mkdir = request.params.get("mkdir").map(|v| v != "false" && v != "0").unwrap_or(true);
+    let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
+    let mkdir = crate::http::bool_param(&request.params, "mkdir", true);
     let mode = request.params.get("mode").and_then(|m| u32::from_str_radix(m, 8).ok());
 
     if mkdir {
@@ -154,10 +151,7 @@ pub fn handle_list(
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
 ) -> std::io::Result<()> {
-    let path = match require_path(request, resp, sandbox) {
-        Ok(p) => p,
-        Err(r) => return r,
-    };
+    let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
     let path = path.as_str();
     let entries = match fs::read_dir(path) {
         Ok(entries) => entries,
@@ -181,10 +175,7 @@ pub fn handle_stat(
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
 ) -> std::io::Result<()> {
-    let path = match require_path(request, resp, sandbox) {
-        Ok(p) => p,
-        Err(r) => return r,
-    };
+    let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
     let path = path.as_str();
     match fs::symlink_metadata(path) {
         Ok(metadata) => resp.json(200, &entry_json(Path::new(path), &metadata)),
@@ -198,12 +189,9 @@ pub fn handle_delete(
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
 ) -> std::io::Result<()> {
-    let path = match require_path(request, resp, sandbox) {
-        Ok(p) => p,
-        Err(r) => return r,
-    };
+    let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
     let path = path.as_str();
-    let recursive = request.params.get("recursive").map(|v| v == "true" || v == "1").unwrap_or(false);
+    let recursive = crate::http::bool_param(&request.params, "recursive", false);
     let metadata = match fs::symlink_metadata(path) {
         Ok(m) => m,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -231,10 +219,7 @@ pub fn handle_mkdir(
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
 ) -> std::io::Result<()> {
-    let path = match require_path(request, resp, sandbox) {
-        Ok(p) => p,
-        Err(r) => return r,
-    };
+    let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
     let path = path.as_str();
     match fs::create_dir_all(path) {
         Ok(()) => {

--- a/src/http.rs
+++ b/src/http.rs
@@ -26,6 +26,16 @@ impl Request {
     }
 }
 
+/// Parse a truthy query parameter: "true"/"1" → true, "false"/"0" → false,
+/// anything else (or absent) → `default`.
+pub fn bool_param(params: &HashMap<String, String>, key: &str, default: bool) -> bool {
+    match params.get(key).map(|v| v.as_str()) {
+        Some("true" | "1") => true,
+        Some("false" | "0") => false,
+        _ => default,
+    }
+}
+
 /// Reads the request head from `reader`. Returns Ok(None) on clean EOF (client
 /// closed a keep-alive connection between requests).
 pub fn read_request(reader: &mut BufReader<TcpStream>) -> io::Result<Option<Request>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod http;
 mod landlock;
 mod sandboxes;
 
+use std::collections::HashMap;
 use std::io::{BufReader, BufWriter};
 use std::net::{TcpListener, TcpStream};
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -16,6 +17,16 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub fn now_ms() -> i64 {
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_millis() as i64
+}
+
+/// Parse `value[key]` (a JSON object of string→string) into a map. Non-string
+/// values become empty strings; a missing or non-object key yields an empty map.
+pub fn json_string_map(value: &serde_json::Value, key: &str) -> HashMap<String, String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_object())
+        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_string())).collect())
+        .unwrap_or_default()
 }
 
 pub struct State {
@@ -227,13 +238,11 @@ fn main() {
                         }
                     }
                     // 2. Shut the host down once it's been empty for the host idle timeout.
-                    if state.sandboxes.count() == 0 {
-                        if now - empty_since > idle_ms {
-                            eprintln!("sbx-server: host empty for {}ms, shutting down", now - empty_since);
-                            std::process::exit(0);
-                        }
-                    } else {
+                    if state.sandboxes.count() != 0 {
                         empty_since = now;
+                    } else if now - empty_since > idle_ms {
+                        eprintln!("sbx-server: host empty for {}ms, shutting down", now - empty_since);
+                        std::process::exit(0);
                     }
                 } else {
                     // Dedicated: the whole job is the sandbox — stop when quiet and idle.

--- a/src/sandboxes.rs
+++ b/src/sandboxes.rs
@@ -355,11 +355,7 @@ pub fn handle_create(
     let json: serde_json::Value =
         if body.is_empty() { serde_json::json!({}) } else { serde_json::from_slice(&body).unwrap_or(serde_json::json!({})) };
     let count = json.get("count").and_then(|v| v.as_u64()).unwrap_or(1).clamp(1, 4096) as usize;
-    let env: HashMap<String, String> = json
-        .get("env")
-        .and_then(|v| v.as_object())
-        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_string())).collect())
-        .unwrap_or_default();
+    let env: HashMap<String, String> = crate::json_string_map(&json, "env");
     let max_procs = json.get("max_procs").and_then(|v| v.as_u64());
     let max_mem_mb = json.get("max_mem_mb").and_then(|v| v.as_u64());
     // Per-sandbox idle timeout (the host has its own, for when it's empty). 0 = never.


### PR DESCRIPTION
Quality-only cleanups surfaced by an in-depth review of the Rust source (reuse / simplification / efficiency / altitude). No behavior change; verified with `cargo check` and `cargo clippy` on `x86_64-unknown-linux-gnu` (no new warnings).

## Changes

- **http**: add `bool_param()` helper, unifying 4 truthy query-param parses (`follow`, `eof`, `recursive`, `mkdir`) that previously used two divergent truthiness rules.
- **main**: add `json_string_map()` helper, dedup the env JSON->map parsing shared by `exec` and `sandboxes`.
- **files**: `require_path` now returns `io::Result<Option<String>>` instead of the awkward `Result<String, io::Result<()>>`, collapsing the copy-pasted 4-line preamble in 6 handlers to a single `let-else`.
- **exec**: add `require_proc()` helper, dedup the pid-lookup-or-404 block across `logs`/`wait`/`kill`/`stdin`.
- **exec**: `Event::to_line` builds the line then pushes `'\n'` instead of a second `format!()` allocation per chunk on the streaming hot path (identical bytes on the wire).
- **exec**: extract `PING_CHUNK` const (a JSON literal previously duplicated in two places).
- **exec**: drop the dead empty `else if` branch in `handle_logs`.
- **main**: flatten the nested `if` in the host idle watchdog.

## Notes

- Formatting was kept in the repo's existing compact hand style; `cargo +nightly fmt` with default settings would reformat the whole codebase (no `rustfmt.toml`), so it was intentionally not run to keep the diff surgical.
- Larger structural ideas from the review (unify the dedicated/host split behind a single resolved `Scope` type, `Arc` payload for `Event` to cut hot-path clones) are deliberately left out of this PR; they are bigger refactors worth their own discussion.