### PR TITLE
docs: binary is distributed via a bucket not a model repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ cargo build --release --target x86_64-unknown-linux-musl
 # → target/x86_64-unknown-linux-musl/release/sbx-server (static-pie, stripped)
 ```
 
-The binary is distributed via a Hugging Face model repo and downloaded at job startup by a
+The binary is distributed via a Hugging Face bucket and downloaded at job startup by a
 `/bin/sh` bootstrap (wget → curl → python3 fallback chain).
 
 ## Status


### PR DESCRIPTION
the README said the binary ships from a model repo, it ships from a HF bucket

disclaimer: my julien-cto agent helped me write this