### PR TITLE
[proxy] In-sandbox port proxy (WS/HTTP passthrough) — POC

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -14,6 +14,8 @@ pub struct Request {
     pub method: String,
     pub path: String,
     pub params: HashMap<String, String>,
+    /// Raw (un-decoded) query string, kept verbatim so the proxy can forward it as-is.
+    pub raw_query: String,
     pub headers: HashMap<String, String>, // keys lowercased
     pub content_length: u64,
     body_consumed: u64,
@@ -87,11 +89,12 @@ pub fn read_request(reader: &mut BufReader<TcpStream>) -> io::Result<Option<Requ
         _ => version == "HTTP/1.1",
     };
 
-    let (path, params) = parse_url(&url);
+    let (path, params, raw_query) = parse_url(&url);
     Ok(Some(Request {
         method,
         path,
         params,
+        raw_query,
         headers,
         content_length,
         body_consumed: 0,
@@ -160,11 +163,24 @@ pub struct ResponseWriter<'a> {
     keep_alive: bool,
     pub started: bool,
     chunked: bool,
+    /// Set when a handler has taken over the raw socket (e.g. the port proxy splices
+    /// bytes directly). The connection loop must then stop driving this connection.
+    pub hijacked: bool,
 }
 
 impl<'a> ResponseWriter<'a> {
     pub fn new(writer: &'a mut BufWriter<TcpStream>, keep_alive: bool) -> Self {
-        Self { writer, keep_alive, started: false, chunked: false }
+        Self { writer, keep_alive, started: false, chunked: false, hijacked: false }
+    }
+
+    /// Take over the raw connection: flush anything pending and hand back an owned
+    /// clone of the underlying socket for direct (proxy) byte-splicing. After this
+    /// the normal response/keep-alive machinery is bypassed (`hijacked` is set).
+    pub fn hijack(&mut self) -> io::Result<TcpStream> {
+        self.writer.flush()?;
+        self.started = true;
+        self.hijacked = true;
+        self.writer.get_ref().try_clone()
     }
 
     fn write_head(&mut self, status: u16, content_type: &str, length: Option<u64>) -> io::Result<()> {
@@ -243,15 +259,15 @@ impl<'a> ResponseWriter<'a> {
     }
 }
 
-/// Split "/v1/files/read?path=/x" into ("/v1/files/read", {"path": "/x"}).
-fn parse_url(url: &str) -> (String, HashMap<String, String>) {
+/// Split "/v1/files/read?path=/x" into ("/v1/files/read", {"path": "/x"}, "path=/x").
+fn parse_url(url: &str) -> (String, HashMap<String, String>, String) {
     let (path, query) = url.split_once('?').unwrap_or((url, ""));
     let mut params = HashMap::new();
     for pair in query.split('&').filter(|p| !p.is_empty()) {
         let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
         params.insert(urldecode(k), urldecode(v));
     }
-    (path.to_string(), params)
+    (path.to_string(), params, query.to_string())
 }
 
 fn urldecode(s: &str) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod exec;
 mod files;
 mod http;
 mod landlock;
+mod proxy;
 mod sandboxes;
 
 use std::collections::HashMap;
@@ -151,6 +152,15 @@ fn route(
         ("DELETE", ["v1", "sandboxes", id, "files", "delete"]) => with_sandbox(state, id, resp, |e, r| files::handle_delete(request, r, Some(&e))),
         ("POST", ["v1", "sandboxes", id, "files", "mkdir"]) => with_sandbox(state, id, resp, |e, r| files::handle_mkdir(request, r, Some(&e))),
 
+        // ---- port proxy: reach a server running inside the sandbox (any method, WS/SSE/HTTP) ----
+        // Dedicated: forward to TCP 127.0.0.1:<port> in the job.
+        (_, ["v1", "proxy", rest @ ..]) => proxy::handle_proxy(None, rest, request, reader, resp),
+        // Host mode: forward to the sandbox's unix socket (it can't bind TCP under Landlock).
+        (_, ["v1", "sandboxes", id, "proxy", rest @ ..]) => match state.sandboxes.get(id) {
+            Some(entry) => proxy::handle_proxy(Some(&entry), rest, request, reader, resp),
+            None => resp.error(404, &format!("no such sandbox: {id}")),
+        },
+
         _ => resp.error(404, &format!("no route: {method} {path}")),
     }
 }
@@ -190,6 +200,11 @@ fn handle_connection(state: Arc<State>, stream: TcpStream) {
         let keep_alive = request.keep_alive;
         let mut resp = ResponseWriter::new(&mut writer, keep_alive);
         let result = route(&state, &mut request, &mut reader, &mut resp);
+        // A hijacked connection (port proxy) owns the socket now — its bytes have been
+        // spliced directly and the request framing no longer applies, so stop here.
+        if resp.hijacked {
+            break;
+        }
         let finished = result.and_then(|_| resp.finish());
         if finished.is_err() || http::drain_body(&mut request, &mut reader).is_err() || !keep_alive {
             break;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,0 +1,180 @@
+//! Port proxy: expose a server running *inside* a sandbox through the one port
+//! the HF Jobs proxy (FRP) forwards to this job.
+//!
+//! Why this exists
+//! ---------------
+//! FRP routes `https://<job_id>--<port>.hf.jobs` to a single pre-registered port
+//! in the job (the sandbox server, 49983). In **host mode** that one job hosts
+//! many sandboxes, and FRP can't address them individually — so the demux has to
+//! happen here. On top of that, host-mode sandboxes are Landlock-confined and
+//! **cannot bind a TCP port** (see `landlock.rs`); they can only create files in
+//! their own home. So a sandbox that wants to expose a server binds a **unix
+//! socket** in its home and we reach it from here (we run as root, outside any
+//! sandbox's Landlock domain).
+//!
+//! Routes:
+//!   ANY /v1/proxy/<port>/<path...>                 → dedicated: TCP 127.0.0.1:<port>
+//!   ANY /v1/sandboxes/<id>/proxy/<port>/<path...>  → host: unix socket in the home
+//!
+//! The proxy is deliberately protocol-agnostic: it replays the request head to the
+//! backend and then splices raw bytes in both directions for the life of the
+//! connection. That makes WebSocket upgrades, SSE and plain HTTP all "just work" —
+//! the inner server performs the actual handshake; we only move bytes.
+
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::{Shutdown, TcpStream};
+use std::os::unix::net::UnixStream;
+use std::sync::Arc;
+
+use crate::http::{Request, ResponseWriter};
+use crate::sandboxes::SandboxEntry;
+
+/// Conventional location, inside a sandbox home, where the sandbox binds its
+/// per-port unix sockets. Exposed to sandbox processes as `$SBX_PROXY_DIR`.
+pub const PROXY_SUBDIR: &str = ".sbx/proxy";
+
+/// A backend connection to the in-sandbox server: a TCP socket (dedicated mode)
+/// or a unix socket in the sandbox home (host mode).
+enum Backend {
+    Tcp(TcpStream),
+    Unix(UnixStream),
+}
+
+impl Backend {
+    fn try_clone(&self) -> io::Result<Backend> {
+        match self {
+            Backend::Tcp(s) => s.try_clone().map(Backend::Tcp),
+            Backend::Unix(s) => s.try_clone().map(Backend::Unix),
+        }
+    }
+
+    fn shutdown(&self, how: Shutdown) {
+        let _ = match self {
+            Backend::Tcp(s) => s.shutdown(how),
+            Backend::Unix(s) => s.shutdown(how),
+        };
+    }
+}
+
+impl Read for Backend {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            Backend::Tcp(s) => s.read(buf),
+            Backend::Unix(s) => s.read(buf),
+        }
+    }
+}
+
+impl Write for Backend {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            Backend::Tcp(s) => s.write(buf),
+            Backend::Unix(s) => s.write(buf),
+        }
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Backend::Tcp(s) => s.flush(),
+            Backend::Unix(s) => s.flush(),
+        }
+    }
+}
+
+/// Split "<port>/<rest...>" out of the path tail after the `proxy` segment.
+/// Returns (port_or_name, "/rest"). A bare "<port>" maps to "/".
+fn split_target(segments: &[&str]) -> Option<(String, String)> {
+    let (port, rest) = segments.split_first()?;
+    if port.is_empty() {
+        return None;
+    }
+    let path = if rest.is_empty() { "/".to_string() } else { format!("/{}", rest.join("/")) };
+    Some((port.to_string(), path))
+}
+
+/// Connect to the in-sandbox backend for `port`. Host mode (sandbox given) →
+/// unix socket `<home>/.sbx/proxy/<port>.sock`; dedicated → TCP `127.0.0.1:<port>`.
+fn connect_backend(sandbox: Option<&Arc<SandboxEntry>>, port: &str) -> io::Result<Backend> {
+    match sandbox {
+        Some(entry) => {
+            let sock = format!("{}/{PROXY_SUBDIR}/{port}.sock", entry.home);
+            UnixStream::connect(&sock).map(Backend::Unix)
+        }
+        None => TcpStream::connect(("127.0.0.1", port.parse::<u16>().map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "proxy port must be a number in dedicated mode")
+        })?))
+        .map(Backend::Tcp),
+    }
+}
+
+/// Build the request head to send to the backend: the request line (with the
+/// `/v1/.../proxy/<port>` prefix stripped) plus the forwarded headers.
+fn build_head(request: &Request, forward_path: &str) -> Vec<u8> {
+    let mut head = Vec::with_capacity(256);
+    let target = if request.raw_query.is_empty() {
+        forward_path.to_string()
+    } else {
+        format!("{forward_path}?{}", request.raw_query)
+    };
+    head.extend_from_slice(format!("{} {} HTTP/1.1\r\n", request.method, target).as_bytes());
+    for (name, value) in &request.headers {
+        // Drop our own auth header (it's for this hop, not the inner server) and the
+        // hop-by-hop keep-alive hint; everything else (Host, Upgrade, Connection,
+        // Sec-WebSocket-*, Content-Length, ...) is forwarded verbatim.
+        if name == "x-sandbox-token" {
+            continue;
+        }
+        head.extend_from_slice(format!("{name}: {value}\r\n").as_bytes());
+    }
+    head.extend_from_slice(b"\r\n");
+    head
+}
+
+/// Handle a proxy request: connect to the backend, replay the head, then splice.
+pub fn handle_proxy(
+    sandbox: Option<&Arc<SandboxEntry>>,
+    segments: &[&str],
+    request: &Request,
+    reader: &mut BufReader<TcpStream>,
+    resp: &mut ResponseWriter,
+) -> io::Result<()> {
+    let Some((port, forward_path)) = split_target(segments) else {
+        return resp.error(404, "proxy target must be /proxy/<port>/<path>");
+    };
+
+    let backend = match connect_backend(sandbox, &port) {
+        Ok(b) => b,
+        Err(e) => return resp.error(502, &format!("cannot reach port {port} in sandbox: {e}")),
+    };
+
+    // From here on we own the raw socket: no more ResponseWriter framing.
+    let head = build_head(request, &forward_path);
+    let mut backend_wr = backend.try_clone()?;
+    let mut backend_rd = backend;
+    let mut outer_rd = reader.get_ref().try_clone()?;
+    let mut outer_wr = resp.hijack()?;
+
+    // Anything BufReader prefetched past the request head is the start of the body /
+    // first client frames — forward it before we start copying from the raw socket.
+    let leftover = reader.buffer().to_vec();
+    let leftover_len = leftover.len();
+    backend_wr.write_all(&head)?;
+    backend_wr.write_all(&leftover)?;
+    backend_wr.flush()?;
+    reader.consume(leftover_len);
+
+    // client → backend (request body, then WebSocket/streamed frames)
+    let pump = std::thread::spawn(move || {
+        let _ = io::copy(&mut outer_rd, &mut backend_wr);
+        // Client hung up: stop the backend from waiting on more input.
+        backend_wr.shutdown(Shutdown::Write);
+        let _ = outer_rd.shutdown(Shutdown::Read);
+    });
+
+    // backend → client (response head, then the response/frame stream)
+    let _ = io::copy(&mut backend_rd, &mut outer_wr);
+    // Backend closed: tear down the other direction so the pump thread unblocks.
+    backend_rd.shutdown(Shutdown::Both);
+    let _ = outer_wr.shutdown(Shutdown::Both);
+    let _ = pump.join();
+    Ok(())
+}

--- a/src/sandboxes.rs
+++ b/src/sandboxes.rs
@@ -126,12 +126,18 @@ impl SandboxRegistry {
         std::fs::set_permissions(&home, std::fs::Permissions::from_mode(0o700))?;
         let tmp = format!("{home}/.tmp");
         std::fs::create_dir_all(&tmp)?;
+        // Where the sandbox binds the unix sockets it wants exposed via the port proxy
+        // (it can't bind TCP under Landlock). Surfaced as $SBX_PROXY_DIR; see proxy.rs.
+        let proxy_dir = format!("{home}/{}", crate::proxy::PROXY_SUBDIR);
+        std::fs::create_dir_all(&proxy_dir)?;
         unsafe {
             let c_home = std::ffi::CString::new(home.as_str()).unwrap();
             let c_tmp = std::ffi::CString::new(tmp.as_str()).unwrap();
             libc::chown(c_home.as_ptr(), uid, uid);
             libc::chown(c_tmp.as_ptr(), uid, uid);
         }
+        // chown the .sbx/proxy chain so the sandbox uid can create sockets in it.
+        chown_into_home(&home, Path::new(&proxy_dir), uid);
         let landlock_fd = crate::landlock::build_ruleset(&home).unwrap_or(-1);
         let entry = Arc::new(SandboxEntry {
             id: id.clone(),
@@ -282,6 +288,8 @@ pub fn base_env(entry: &SandboxEntry) -> Vec<(String, String)> {
         ("USER".to_string(), format!("sbx-{}", entry.id)),
         ("LOGNAME".to_string(), format!("sbx-{}", entry.id)),
         ("SBX_SANDBOX_ID".to_string(), entry.id.clone()),
+        // Bind a unix socket at $SBX_PROXY_DIR/<port>.sock to expose it via the port proxy.
+        ("SBX_PROXY_DIR".to_string(), format!("{}/{}", entry.home, crate::proxy::PROXY_SUBDIR)),
     ];
     env.extend(entry.env.iter().map(|(k, v)| (k.clone(), v.clone())));
     env


### PR DESCRIPTION
> ⚠️ **POC / draft.** Opening for discussion alongside the client-side PR in `huggingface_hub`: huggingface/huggingface_hub#4444. Not meant to merge as-is.

## Summary

Adds a **port proxy** to the sandbox server: reach a server running *inside* a sandbox (WebSocket, SSE or plain HTTP) from the outside, through the **single** port that the HF Jobs proxy (FRP) forwards to this job. No extra exposed ports, no per-sandbox FRP registration.

New routes (any HTTP method):

```
ANY /v1/proxy/<port>/<path...>                 → dedicated: TCP 127.0.0.1:<port>
ANY /v1/sandboxes/<id>/proxy/<port>/<path...>  → host:      unix socket in the sandbox home
```

The matching client change (`Sandbox.proxy_url`) and the full usage docs live in the companion `huggingface_hub` PR (huggingface/huggingface_hub#4444).

## How it works

- **Protocol-agnostic passthrough.** The handler connects to the in-sandbox backend, replays the request head (the `/v1/.../proxy/<port>` prefix stripped, query string preserved, our own `X-Sandbox-Token` dropped), then **splices raw bytes in both directions** for the life of the connection. It never parses the response, so `Upgrade: websocket` (101), SSE and plain HTTP all pass through unchanged — the *inner* server does the actual handshake; we only move bytes.
- **Host mode uses a unix socket.** Host-mode sandboxes are Landlock-confined and **cannot bind a TCP port** (this is deliberate — it closes inter-sandbox localhost channels). They *can* create files in their own home, so a sandbox binds a unix socket at `$SBX_PROXY_DIR/<port>.sock` and the server (root, outside any sandbox's Landlock domain) connects to it. `$SBX_PROXY_DIR` (`<home>/.sbx/proxy`) is created + chowned at sandbox creation and injected into the sandbox env.
- **Dedicated mode uses TCP.** The job process isn't Landlock-confined, so it binds `127.0.0.1:<port>` normally — but still reached **through the same `49983` server port**, not a separately-exposed port (intentional: keep a single ingress; we can add direct `expose=` later if ever needed).
- **Auth unchanged.** Proxy requests go through the existing two layers: the HF token at FRP and `X-Sandbox-Token` at the sandbox server (the token check runs *before* routing).

## Implementation notes

- `src/proxy.rs` — the new handler + a small `Backend` enum (`TcpStream` / `UnixStream`) so the splice code is identical for both modes.
- `src/http.rs` — `Request.raw_query` (forward the query verbatim) and `ResponseWriter::hijack()` (flush, hand back an owned socket clone, mark the connection taken over).
- `src/main.rs` — two method-agnostic routes + the connection loop bails out on a hijacked connection.
- `src/sandboxes.rs` — create/chown `$SBX_PROXY_DIR`, export it in the sandbox env.

## Pros / cons

**Pros**
- Single ingress port (49983) for everything; no per-sandbox/per-port FRP routes.
- Works the same for dedicated and host/pool sandboxes; one client API.
- Server stays dumb & protocol-agnostic (no WS framing, no per-protocol code).
- Host-mode isolation preserved: sockets live in each sandbox's private `0700` home, addressed by sandbox id — no port collisions, no cross-sandbox reachability.

**Cons / open questions**
- Host mode requires the inner server to bind a **unix socket** instead of a TCP port (`--uds`); most servers support it, but it's a small ask.
- A long-lived spliced connection doesn't re-`touch()` the sandbox, so idle eviction could fire mid-stream. It's safe **if** the inner server was started via `run(background=True)` (counts as a running proc); otherwise we'd want the live proxy connection itself to keep the sandbox alive. (follow-up)
- One thread per direction per connection (fine for a PoC; revisit for high fan-out).
- No per-connection limits / timeouts yet beyond what FRP imposes.

## Testing

Validated the splice + WebSocket upgrade + plain-HTTP path locally against the dedicated/TCP route (a real `websockets` echo server and an `http.server` behind the proxy — bidirectional, multi-frame, path+query preserved). The host-mode UDS path uses the identical splice (only `connect()` differs); full host-mode e2e needs a real root Job.
