### PR TITLE
Put ~/.local/bin on the sandbox PATH

### DIFF
--- a/src/sandboxes.rs
+++ b/src/sandboxes.rs
@@ -282,7 +282,13 @@ pub fn pre_exec_isolation(entry: &SandboxEntry) -> impl FnMut() -> std::io::Resu
 /// it may contain job secrets that belong to the host, not the sandboxes).
 pub fn base_env(entry: &SandboxEntry) -> Vec<(String, String)> {
     let mut env = vec![
-        ("PATH".to_string(), "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string()),
+        // `~/.local/bin` first: a Landlock-confined sandbox can't write to the system
+        // site (/usr is read-only), so `pip install` falls back to a `--user` install
+        // there — its console scripts (uvicorn, ...) must be on PATH to be runnable.
+        (
+            "PATH".to_string(),
+            format!("{}/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", entry.home),
+        ),
         ("HOME".to_string(), entry.home.clone()),
         ("TMPDIR".to_string(), format!("{}/.tmp", entry.home)),
         ("USER".to_string(), format!("sbx-{}", entry.id)),


### PR DESCRIPTION
## Symptom

Running the pool + port-proxy demo (uvicorn on a unix socket, reached via `proxy_url_for`) fails at the proxy step:

```
{"error": "cannot reach port 8000 in sandbox: No such file or directory (os error 2)"}
```

`os error 2` is `ENOENT`: the proxy dials `<home>/.sbx/proxy/8000.sock`, but that socket was never created — the backend server never came up.

## Root cause

A pool (host-mode) sandbox runs **Landlock-confined**, so `/usr` is read-only and `pip install` can't write to the system site-packages. pip therefore auto-selects a **`--user`** install into `~/.local`, which *succeeds silently* (so `run()` doesn't raise). But the resulting console scripts (`uvicorn`, …) land in `~/.local/bin`, which was **not** on the sandbox `PATH`:

```
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

So `uvicorn app:app --uds $SBX_PROXY_DIR/8000.sock` (run in the background) fails with *command not found*, exits before binding the socket, and the proxy then hits a path that doesn't exist → `ENOENT`.

## Fix

Prepend `$HOME/.local/bin` to `PATH` in `base_env`, so pip's `--user` scripts are runnable:

```
PATH=<home>/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

(User-site *imports* already work — Python enables the user site automatically — so only the scripts dir was missing.)

## Note on verification

I could not reproduce host mode locally (it needs root + `CAP_SETUID`/Landlock, unavailable in my dev env), so this isn't runtime-verified end-to-end. The change is purely additive to `PATH` and the causal chain (Landlock RO `/usr` → pip `--user` → `~/.local/bin` off PATH → `uvicorn` not found → no socket → proxy `ENOENT`) is deterministic. Worth a quick confirm on a real Job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)