### PR TITLE
ci: add cargo test + release build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+# Runs the test suite and a release build on every push to main and on all PRs
+# so regressions are caught before they land.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Build release
+        run: cargo build --release


### PR DESCRIPTION
Adds a `CI` GitHub Actions workflow that runs the test suite and a release build.

## What it does
- Runs `cargo test` and `cargo build --release`
- Triggers on pushes to `main` and on all pull requests
- Caches the cargo registry and `target/` to speed up runs
- Cancels superseded in-progress runs per ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)