### PR TITLE
Harden pooled sandbox isolation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "sbx-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libc",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbx-server"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ DELETE /v1/files/delete?path=&recursive=
 POST /v1/files/mkdir?path=
 
 # host mode (many sandboxes per job)
-POST   /v1/sandboxes        {count?, env?, max_procs?, max_mem_mb?}  → {"sandboxes":[{id,uid,home}]}
+POST   /v1/sandboxes        {count?, env?, max_procs?, max_mem_mb?}  → {"sandboxes":[{id,token,uid,home}]}
 GET    /v1/sandboxes                                                 → live sandbox list
 DELETE /v1/sandboxes                                                 → delete all
 DELETE /v1/sandboxes/{id}                                            → delete one (frees the uid)
+GET    /v1/sandboxes/{id}/token                                      → recover its scoped token
 # every dedicated route above also exists scoped to a sandbox, e.g.:
 POST   /v1/sandboxes/{id}/exec        ...   GET /v1/sandboxes/{id}/processes
 GET    /v1/sandboxes/{id}/files/read  ...   PUT /v1/sandboxes/{id}/files/write
@@ -65,16 +66,17 @@ GET    /v1/sandboxes/{id}/files/read  ...   PUT /v1/sandboxes/{id}/files/write
 
 `cmd` is either a string (run via `/bin/sh -c`) or an argv array. Pass `shell` (bool) to make
 that choice explicit instead of inferring it from the type: `shell=true` requires a string,
-`shell=false` requires an argv array. In host mode, file paths
-are rooted at the sandbox's private home (a leading `/` is taken relative to it) and created
-files are `chown`ed to the sandbox uid.
+`shell=false` requires an argv array. In host mode, file paths are rooted at the sandbox's
+private home (a leading `/` is taken relative to it). The privileged file API resolves every
+component relative to an open home directory fd and never follows symlinks; it assigns
+ownership through already-open descriptors rather than path-based `chown` calls.
 
 ## Configuration (env vars)
 
 | var | default | meaning |
 |---|---|---|
 | `SBX_PORT` | `8000` | listen port (the client uses 49983 to keep common dev ports free) |
-| `SBX_TOKEN` | unset | if set, all endpoints except `/health` require the `X-Sandbox-Token` header (constant-time compare); removed from the env before any child process spawns |
+| `SBX_TOKEN` | unset | dedicated auth token, or required host-mode management token; removed from the env before any child process spawns |
 | `SBX_IDLE_TIMEOUT` | unset | seconds of inactivity (no authed request, no running process) before clean exit |
 
 ## Security model
@@ -83,8 +85,14 @@ Two layers when running on HF Jobs:
 
 1. The Jobs proxy requires an HF token with read access to the job's namespace.
 2. `SBX_TOKEN` is delivered via encrypted job secrets; the client derives it as
-   `HMAC-SHA256(user_hf_token, nonce)` with the nonce stored in job labels — so
-   reconnection is stateless and the HF token itself never enters the sandbox.
+   `HMAC-SHA256(user_hf_token, nonce)` with the nonce stored in job labels. In host mode it is
+   accepted for pool management and backwards-compatible non-proxy calls. Every pooled
+   sandbox receives a separate random capability token for its scoped routes and port proxy.
+
+Dedicated routes are unavailable in host mode, and host routes are unavailable in dedicated
+mode. A pooled sandbox token can therefore neither address a sibling nor reach a root-running
+unscoped route. Older clients may continue using the host token for ordinary scoped calls, but
+must upgrade before using a pooled port proxy.
 
 ## Build
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,79 +1,397 @@
 //! Filesystem endpoints: raw-body file transfer (no base64), directory
 //! listing, stat, delete, mkdir.
+//!
+//! Dedicated-mode paths are ordinary container paths. Host-mode paths are
+//! resolved descriptor-by-descriptor from an open sandbox-home fd, with
+//! `O_NOFOLLOW` on every component. Sandboxes may create symlinks for their own
+//! processes, but the privileged file API never follows them.
 
-use std::fs;
-use std::io::{BufReader, Read, Write};
+use std::ffi::{CString, OsStr, OsString};
+use std::fs::{self, File, Metadata};
+use std::io::{self, BufReader, Read, Seek, Write};
 use std::net::TcpStream;
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use crate::http::{stream_body, Request, ResponseWriter};
 use crate::sandboxes::SandboxEntry;
 
-/// Resolve the request's `path` parameter to the absolute filesystem path to act
-/// on. In dedicated mode (`sandbox = None`) the path is used as-is; in host mode
-/// it is rooted at the sandbox home (see `sandboxes::resolve_in_home`).
+fn c_path(path: &OsStr) -> io::Result<CString> {
+    CString::new(path.as_bytes()).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "path contains NUL"))
+}
+
+fn open_fd_at(dirfd: RawFd, name: &OsStr, flags: i32, mode: libc::mode_t) -> io::Result<File> {
+    let name = c_path(name)?;
+    let fd = unsafe { libc::openat(dirfd, name.as_ptr(), flags | libc::O_CLOEXEC | libc::O_NOFOLLOW, mode) };
+    if fd < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+}
+
+fn open_dir_at(dirfd: RawFd, name: &OsStr) -> io::Result<File> {
+    open_fd_at(dirfd, name, libc::O_RDONLY | libc::O_DIRECTORY, 0)
+}
+
+fn dup_file(file: &File) -> io::Result<File> {
+    let fd = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if fd < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(unsafe { File::from_raw_fd(fd) })
+    }
+}
+
+fn normalized_relative(path: &str) -> PathBuf {
+    let mut result = PathBuf::new();
+    for component in Path::new(path).components() {
+        match component {
+            Component::Normal(name) => result.push(name),
+            Component::ParentDir => {
+                result.pop();
+            }
+            // RootDir / CurDir / Prefix are ignored: host-mode paths are rooted
+            // at the sandbox home regardless of a leading slash.
+            _ => {}
+        }
+    }
+    result
+}
+
+fn path_components(path: &Path) -> Vec<OsString> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(name) => Some(name.to_os_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn proc_fd_path(file: &File) -> PathBuf {
+    PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()))
+}
+
+fn proc_child_path(dir: &File, name: &OsStr) -> PathBuf {
+    let mut path = proc_fd_path(dir);
+    path.push(name);
+    path
+}
+
+struct ScopedRoot {
+    home: PathBuf,
+    dir: File,
+    uid: u32,
+}
+
+impl ScopedRoot {
+    fn open(entry: &SandboxEntry) -> io::Result<Self> {
+        let home = PathBuf::from(&entry.home);
+        let home_c = c_path(home.as_os_str())?;
+        let fd = unsafe {
+            libc::open(
+                home_c.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self { home, dir: unsafe { File::from_raw_fd(fd) }, uid: entry.uid })
+    }
+
+    #[cfg(test)]
+    fn open_for_test(home: &Path) -> io::Result<Self> {
+        let home_c = c_path(home.as_os_str())?;
+        let fd = unsafe {
+            libc::open(
+                home_c.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(Self {
+            home: home.to_path_buf(),
+            dir: unsafe { File::from_raw_fd(fd) },
+            uid: unsafe { libc::geteuid() },
+        })
+    }
+
+    fn chown(&self, file: &File) -> io::Result<()> {
+        if unsafe { libc::fchown(file.as_raw_fd(), self.uid, self.uid) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+
+    fn walk_dir(&self, components: &[OsString], create: bool) -> io::Result<File> {
+        let mut dir = dup_file(&self.dir)?;
+        for name in components {
+            match open_dir_at(dir.as_raw_fd(), name) {
+                Ok(child) => dir = child,
+                Err(error) if create && error.kind() == io::ErrorKind::NotFound => {
+                    let name_c = c_path(name)?;
+                    let created = unsafe { libc::mkdirat(dir.as_raw_fd(), name_c.as_ptr(), 0o755) };
+                    if created != 0 {
+                        let mkdir_error = io::Error::last_os_error();
+                        if mkdir_error.kind() != io::ErrorKind::AlreadyExists {
+                            return Err(mkdir_error);
+                        }
+                    }
+                    let child = open_dir_at(dir.as_raw_fd(), name)?;
+                    if created == 0 {
+                        self.chown(&child)?;
+                    }
+                    dir = child;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(dir)
+    }
+
+    fn parent_and_name(&self, relative: &Path, create_parents: bool) -> io::Result<(File, OsString)> {
+        let components = path_components(relative);
+        let Some((name, parents)) = components.split_last() else {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "path refers to the sandbox root"));
+        };
+        Ok((self.walk_dir(parents, create_parents)?, name.clone()))
+    }
+
+    fn open_read(&self, relative: &Path) -> io::Result<File> {
+        if relative.as_os_str().is_empty() {
+            return dup_file(&self.dir);
+        }
+        let (parent, name) = self.parent_and_name(relative, false)?;
+        open_fd_at(parent.as_raw_fd(), &name, libc::O_RDONLY, 0)
+    }
+
+    fn open_dir(&self, relative: &Path) -> io::Result<File> {
+        self.walk_dir(&path_components(relative), false)
+    }
+
+    fn open_write(&self, relative: &Path, create_parents: bool, offset: Option<u64>) -> io::Result<File> {
+        let (parent, name) = self.parent_and_name(relative, create_parents)?;
+        let flags = libc::O_WRONLY | libc::O_CREAT | if offset.is_some() { 0 } else { libc::O_TRUNC };
+        let mut file = open_fd_at(parent.as_raw_fd(), &name, flags, 0o666)?;
+        self.chown(&file)?;
+        if let Some(offset) = offset {
+            file.seek(io::SeekFrom::Start(offset))?;
+        }
+        Ok(file)
+    }
+
+    fn metadata(&self, relative: &Path) -> io::Result<Metadata> {
+        if relative.as_os_str().is_empty() {
+            return self.dir.metadata();
+        }
+        let (parent, name) = self.parent_and_name(relative, false)?;
+        fs::symlink_metadata(proc_child_path(&parent, &name))
+    }
+
+    fn mkdir_all(&self, relative: &Path) -> io::Result<()> {
+        self.walk_dir(&path_components(relative), true).map(drop)
+    }
+
+    fn delete(&self, relative: &Path, recursive: bool) -> io::Result<()> {
+        let (parent, name) = self.parent_and_name(relative, false)?;
+        let metadata = fs::symlink_metadata(proc_child_path(&parent, &name))?;
+        if metadata.is_dir() {
+            if recursive {
+                remove_tree_at(&parent, &name)
+            } else {
+                unlink_at(&parent, &name, libc::AT_REMOVEDIR)
+            }
+        } else {
+            unlink_at(&parent, &name, 0)
+        }
+    }
+}
+
+fn unlink_at(parent: &File, name: &OsStr, flags: i32) -> io::Result<()> {
+    let name = c_path(name)?;
+    if unsafe { libc::unlinkat(parent.as_raw_fd(), name.as_ptr(), flags) } == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+fn remove_tree_at(parent: &File, name: &OsStr) -> io::Result<()> {
+    let dir = open_dir_at(parent.as_raw_fd(), name)?;
+    for entry in fs::read_dir(proc_fd_path(&dir))? {
+        let entry = entry?;
+        let child_name = entry.file_name();
+        let metadata = fs::symlink_metadata(proc_child_path(&dir, &child_name))?;
+        if metadata.is_dir() {
+            remove_tree_at(&dir, &child_name)?;
+        } else {
+            unlink_at(&dir, &child_name, 0)?;
+        }
+    }
+    unlink_at(parent, name, libc::AT_REMOVEDIR)
+}
+
+enum ApiPath {
+    Dedicated(PathBuf),
+    Scoped { root: ScopedRoot, relative: PathBuf },
+}
+
+impl ApiPath {
+    fn resolve(raw: &str, sandbox: Option<&SandboxEntry>) -> io::Result<Self> {
+        match sandbox {
+            None => Ok(Self::Dedicated(PathBuf::from(raw))),
+            Some(entry) => Ok(Self::Scoped { root: ScopedRoot::open(entry)?, relative: normalized_relative(raw) }),
+        }
+    }
+
+    fn display(&self) -> PathBuf {
+        match self {
+            Self::Dedicated(path) => path.clone(),
+            Self::Scoped { root, relative } => root.home.join(relative),
+        }
+    }
+
+    fn open_read(&self) -> io::Result<File> {
+        match self {
+            Self::Dedicated(path) => File::open(path),
+            Self::Scoped { root, relative } => root.open_read(relative),
+        }
+    }
+
+    fn open_write(&self, create_parents: bool, offset: Option<u64>) -> io::Result<File> {
+        match self {
+            Self::Dedicated(path) => {
+                if create_parents {
+                    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+                        fs::create_dir_all(parent)?;
+                    }
+                }
+                let mut options = fs::OpenOptions::new();
+                options.write(true).create(true).truncate(offset.is_none());
+                let mut file = options.open(path)?;
+                if let Some(offset) = offset {
+                    file.seek(io::SeekFrom::Start(offset))?;
+                }
+                Ok(file)
+            }
+            Self::Scoped { root, relative } => root.open_write(relative, create_parents, offset),
+        }
+    }
+
+    fn metadata(&self) -> io::Result<Metadata> {
+        match self {
+            Self::Dedicated(path) => fs::symlink_metadata(path),
+            Self::Scoped { root, relative } => root.metadata(relative),
+        }
+    }
+
+    fn list(&self) -> io::Result<Vec<(PathBuf, Metadata)>> {
+        let (directory, display) = match self {
+            Self::Dedicated(path) => (fs::read_dir(path)?, path.clone()),
+            Self::Scoped { root, relative } => {
+                let dir = root.open_dir(relative)?;
+                (fs::read_dir(proc_fd_path(&dir))?, root.home.join(relative))
+            }
+        };
+        let mut entries = Vec::new();
+        for entry in directory.flatten() {
+            // `DirEntry::metadata` follows a final symlink. Keep list/stat
+            // consistent with the scoped API's no-follow policy.
+            if let Ok(metadata) = fs::symlink_metadata(entry.path()) {
+                entries.push((display.join(entry.file_name()), metadata));
+            }
+        }
+        Ok(entries)
+    }
+
+    fn mkdir_all(&self) -> io::Result<()> {
+        match self {
+            Self::Dedicated(path) => fs::create_dir_all(path),
+            Self::Scoped { root, relative } => root.mkdir_all(relative),
+        }
+    }
+
+    fn delete(&self, recursive: bool) -> io::Result<()> {
+        match self {
+            Self::Dedicated(path) => {
+                let metadata = fs::symlink_metadata(path)?;
+                if metadata.is_dir() {
+                    if recursive { fs::remove_dir_all(path) } else { fs::remove_dir(path) }
+                } else {
+                    fs::remove_file(path)
+                }
+            }
+            Self::Scoped { root, relative } => root.delete(relative, recursive),
+        }
+    }
+}
+
 fn require_path(
     request: &Request,
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
-) -> std::io::Result<Option<String>> {
-    let raw = match request.params.get("path").map(|s| s.as_str()) {
-        Some(p) if !p.is_empty() => p,
+) -> io::Result<Option<ApiPath>> {
+    let raw = match request.params.get("path").map(String::as_str) {
+        Some(path) if !path.is_empty() => path,
         _ => {
             resp.error(400, "missing 'path' query parameter")?;
             return Ok(None);
         }
     };
-    Ok(Some(match sandbox {
-        None => raw.to_string(),
-        Some(sbx) => crate::sandboxes::resolve_in_home(&sbx.home, raw).to_string_lossy().into_owned(),
-    }))
+    match ApiPath::resolve(raw, sandbox) {
+        Ok(path) => Ok(Some(path)),
+        Err(error) => {
+            resp.error(400, &format!("cannot resolve {raw}: {error}"))?;
+            Ok(None)
+        }
+    }
 }
 
 pub fn handle_read(
     request: &mut Request,
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
-    let path = path.as_str();
-    let mut file = match fs::File::open(path) {
-        Ok(f) => f,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return resp.error(404, &format!("no such file: {path}"))
+    let display = path.display().to_string_lossy().into_owned();
+    let mut file = match path.open_read() {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return resp.error(404, &format!("no such file: {display}"))
         }
-        Err(e) => return resp.error(400, &format!("cannot open {path}: {e}")),
+        Err(error) => return resp.error(400, &format!("cannot open {display}: {error}")),
     };
     let metadata = file.metadata()?;
     if metadata.is_dir() {
-        return resp.error(409, &format!("is a directory: {path}"));
+        return resp.error(409, &format!("is a directory: {display}"));
     }
-    // Optional offset/length for parallel ranged downloads.
-    let offset: u64 = request.params.get("offset").and_then(|v| v.parse().ok()).unwrap_or(0);
+    let offset: u64 = request.params.get("offset").and_then(|value| value.parse().ok()).unwrap_or(0);
     let length = request
         .params
         .get("length")
-        .and_then(|v| v.parse::<u64>().ok())
+        .and_then(|value| value.parse::<u64>().ok())
         .unwrap_or(u64::MAX)
         .min(metadata.len().saturating_sub(offset));
     if offset > 0 {
-        use std::io::Seek;
-        file.seek(std::io::SeekFrom::Start(offset))?;
+        file.seek(io::SeekFrom::Start(offset))?;
     }
     resp.start_fixed(200, "application/octet-stream", length)?;
-    // Heap, not stack (256 KiB would be needlessly large on the per-connection
-    // thread stack), and sized to the request so small reads don't allocate 256 KiB.
-    let mut buf = vec![0u8; length.min(256 * 1024) as usize];
+    let mut buffer = vec![0u8; length.min(256 * 1024) as usize];
     let mut remaining = length;
     while remaining > 0 {
-        let max = buf.len().min(remaining as usize);
-        let n = file.read(&mut buf[..max])?;
-        if n == 0 {
+        let max = buffer.len().min(remaining as usize);
+        let read = file.read(&mut buffer[..max])?;
+        if read == 0 {
             break;
         }
-        resp.raw(&buf[..n])?;
-        remaining -= n as u64;
+        resp.raw(&buffer[..read])?;
+        remaining -= read as u64;
     }
     resp.flush()
 }
@@ -83,49 +401,24 @@ pub fn handle_write(
     reader: &mut BufReader<TcpStream>,
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
+    let display = path.display().to_string_lossy().into_owned();
     let mkdir = crate::http::bool_param(&request.params, "mkdir", true);
-    let mode = request.params.get("mode").and_then(|m| u32::from_str_radix(m, 8).ok());
-
-    if mkdir {
-        if let Some(parent) = Path::new(&path).parent() {
-            if !parent.as_os_str().is_empty() {
-                if let Err(e) = fs::create_dir_all(parent) {
-                    return resp.error(400, &format!("cannot create parent dirs for {path}: {e}"));
-                }
-            }
-        }
-    }
-    // Optional offset for parallel chunked uploads: open without truncating and
-    // write at the given position (the file is created if missing).
-    let mut file = match request.params.get("offset").and_then(|v| v.parse::<u64>().ok()) {
-        Some(offset) => match fs::OpenOptions::new().write(true).create(true).open(&path) {
-            Ok(mut f) => {
-                use std::io::Seek;
-                if let Err(e) = f.seek(std::io::SeekFrom::Start(offset)) {
-                    return resp.error(400, &format!("cannot seek in {path}: {e}"));
-                }
-                f
-            }
-            Err(e) => return resp.error(400, &format!("cannot open {path}: {e}")),
-        },
-        None => match fs::File::create(&path) {
-            Ok(f) => f,
-            Err(e) => return resp.error(400, &format!("cannot create {path}: {e}")),
-        },
+    let mode = request.params.get("mode").and_then(|value| u32::from_str_radix(value, 8).ok());
+    let offset = request.params.get("offset").and_then(|value| value.parse::<u64>().ok());
+    let mut file = match path.open_write(mkdir, offset) {
+        Ok(file) => file,
+        Err(error) => return resp.error(400, &format!("cannot open {display}: {error}")),
     };
     let size = stream_body(request, reader, |chunk| file.write_all(chunk))?;
     if let Some(mode) = mode {
-        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(mode));
+        let _ = file.set_permissions(fs::Permissions::from_mode(mode));
     }
-    if let Some(sbx) = sandbox {
-        crate::sandboxes::chown_into_home(&sbx.home, Path::new(&path), sbx.uid);
-    }
-    resp.json(200, &serde_json::json!({"path": path, "size": size}))
+    resp.json(200, &serde_json::json!({"path": display, "size": size}))
 }
 
-fn entry_json(path: &Path, metadata: &fs::Metadata) -> serde_json::Value {
+fn entry_json(path: &Path, metadata: &Metadata) -> serde_json::Value {
     let file_type = if metadata.is_dir() {
         "dir"
     } else if metadata.file_type().is_symlink() {
@@ -136,10 +429,10 @@ fn entry_json(path: &Path, metadata: &fs::Metadata) -> serde_json::Value {
     let mtime_ms = metadata
         .modified()
         .ok()
-        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-        .map(|d| d.as_millis() as i64);
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as i64);
     serde_json::json!({
-        "name": path.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default(),
+        "name": path.file_name().map(|name| name.to_string_lossy().into_owned()).unwrap_or_default(),
         "path": path.to_string_lossy(),
         "type": file_type,
         "size": metadata.len(),
@@ -152,22 +445,17 @@ pub fn handle_list(
     request: &mut Request,
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
-    let path = path.as_str();
-    let entries = match fs::read_dir(path) {
+    let display = path.display().to_string_lossy().into_owned();
+    let entries = match path.list() {
         Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return resp.error(404, &format!("no such directory: {path}"))
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return resp.error(404, &format!("no such directory: {display}"))
         }
-        Err(e) => return resp.error(400, &format!("cannot list {path}: {e}")),
+        Err(error) => return resp.error(400, &format!("cannot list {display}: {error}")),
     };
-    let mut items = Vec::new();
-    for entry in entries.flatten() {
-        if let Ok(metadata) = entry.metadata() {
-            items.push(entry_json(&entry.path(), &metadata));
-        }
-    }
+    let mut items: Vec<_> = entries.iter().map(|(path, metadata)| entry_json(path, metadata)).collect();
     items.sort_by(|a, b| a["name"].as_str().cmp(&b["name"].as_str()));
     resp.json(200, &serde_json::json!({"entries": items}))
 }
@@ -176,13 +464,15 @@ pub fn handle_stat(
     request: &mut Request,
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
-    let path = path.as_str();
-    match fs::symlink_metadata(path) {
-        Ok(metadata) => resp.json(200, &entry_json(Path::new(path), &metadata)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => resp.error(404, &format!("no such path: {path}")),
-        Err(e) => resp.error(400, &format!("cannot stat {path}: {e}")),
+    let display = path.display();
+    match path.metadata() {
+        Ok(metadata) => resp.json(200, &entry_json(&display, &metadata)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            resp.error(404, &format!("no such path: {}", display.to_string_lossy()))
+        }
+        Err(error) => resp.error(400, &format!("cannot stat {}: {error}", display.to_string_lossy())),
     }
 }
 
@@ -190,29 +480,14 @@ pub fn handle_delete(
     request: &mut Request,
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
-    let path = path.as_str();
+    let display = path.display().to_string_lossy().into_owned();
     let recursive = crate::http::bool_param(&request.params, "recursive", false);
-    let metadata = match fs::symlink_metadata(path) {
-        Ok(m) => m,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return resp.error(404, &format!("no such path: {path}"))
-        }
-        Err(e) => return resp.error(400, &format!("cannot stat {path}: {e}")),
-    };
-    let result = if metadata.is_dir() {
-        if recursive {
-            fs::remove_dir_all(path)
-        } else {
-            fs::remove_dir(path)
-        }
-    } else {
-        fs::remove_file(path)
-    };
-    match result {
-        Ok(()) => resp.json(200, &serde_json::json!({"deleted": path})),
-        Err(e) => resp.error(400, &format!("cannot delete {path}: {e}")),
+    match path.delete(recursive) {
+        Ok(()) => resp.json(200, &serde_json::json!({"deleted": display})),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => resp.error(404, &format!("no such path: {display}")),
+        Err(error) => resp.error(400, &format!("cannot delete {display}: {error}")),
     }
 }
 
@@ -220,16 +495,80 @@ pub fn handle_mkdir(
     request: &mut Request,
     resp: &mut ResponseWriter,
     sandbox: Option<&SandboxEntry>,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     let Some(path) = require_path(request, resp, sandbox)? else { return Ok(()) };
-    let path = path.as_str();
-    match fs::create_dir_all(path) {
-        Ok(()) => {
-            if let Some(sbx) = sandbox {
-                crate::sandboxes::chown_into_home(&sbx.home, Path::new(path), sbx.uid);
-            }
-            resp.json(200, &serde_json::json!({"created": path}))
-        }
-        Err(e) => resp.error(400, &format!("cannot mkdir {path}: {e}")),
+    let display = path.display().to_string_lossy().into_owned();
+    match path.mkdir_all() {
+        Ok(()) => resp.json(200, &serde_json::json!({"created": display})),
+        Err(error) => resp.error(400, &format!("cannot mkdir {display}: {error}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn layout() -> (PathBuf, PathBuf, PathBuf) {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let base = std::env::temp_dir().join(format!(
+            "sbx-files-test-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed)
+        ));
+        let home = base.join("home");
+        let outside = base.join("outside");
+        fs::create_dir_all(&home).unwrap();
+        fs::create_dir_all(&outside).unwrap();
+        (base, home, outside)
+    }
+
+    #[test]
+    fn scoped_files_reject_final_symlinks() {
+        let (base, home, outside) = layout();
+        fs::write(outside.join("secret"), b"secret").unwrap();
+        std::os::unix::fs::symlink(outside.join("secret"), home.join("escape")).unwrap();
+        let root = ScopedRoot::open_for_test(&home).unwrap();
+
+        assert!(root.open_read(Path::new("escape")).is_err());
+        assert!(root.open_write(Path::new("escape"), true, None).is_err());
+        assert_eq!(fs::read(outside.join("secret")).unwrap(), b"secret");
+        fs::remove_dir_all(base).unwrap();
+    }
+
+    #[test]
+    fn scoped_files_reject_intermediate_symlinks() {
+        let (base, home, outside) = layout();
+        std::os::unix::fs::symlink(&outside, home.join("escape")).unwrap();
+        let root = ScopedRoot::open_for_test(&home).unwrap();
+
+        assert!(root.open_write(Path::new("escape/created"), true, None).is_err());
+        assert!(!outside.join("created").exists());
+        fs::remove_dir_all(base).unwrap();
+    }
+
+    #[test]
+    fn deleting_symlink_does_not_touch_target() {
+        let (base, home, outside) = layout();
+        fs::write(outside.join("secret"), b"secret").unwrap();
+        std::os::unix::fs::symlink(&outside, home.join("escape")).unwrap();
+        let root = ScopedRoot::open_for_test(&home).unwrap();
+
+        root.delete(Path::new("escape"), true).unwrap();
+        assert_eq!(fs::read(outside.join("secret")).unwrap(), b"secret");
+        assert!(!home.join("escape").exists());
+        fs::remove_dir_all(base).unwrap();
+    }
+
+    #[test]
+    fn scoped_write_creates_owned_parent_chain() {
+        let (base, home, _) = layout();
+        let root = ScopedRoot::open_for_test(&home).unwrap();
+        let mut file = root.open_write(Path::new("a/b/file"), true, None).unwrap();
+        file.write_all(b"ok").unwrap();
+        drop(file);
+
+        assert_eq!(fs::read(home.join("a/b/file")).unwrap(), b"ok");
+        fs::remove_dir_all(base).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,9 +51,59 @@ fn ct_eq(a: &str, b: &str) -> bool {
     a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
 }
 
-fn authorized(state: &State, request: &Request) -> bool {
-    let Some(expected) = &state.token else { return true };
-    request.header("x-sandbox-token").map(|v| ct_eq(v, expected)).unwrap_or(false)
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AuthScope {
+    /// The dedicated token, or the pool host-management token.
+    Host,
+    /// A capability token bound to exactly one pooled sandbox.
+    Sandbox,
+}
+
+fn host_token_matches(state: &State, request: &Request) -> bool {
+    match &state.token {
+        None => true,
+        Some(expected) => request.header("x-sandbox-token").map(|token| ct_eq(token, expected)).unwrap_or(false),
+    }
+}
+
+fn classify_scoped_token(provided: &str, sandbox_token: &str, host_token: Option<&str>) -> Option<AuthScope> {
+    if ct_eq(provided, sandbox_token) {
+        Some(AuthScope::Sandbox)
+    } else if host_token.is_some_and(|expected| ct_eq(provided, expected)) {
+        // Rolling-upgrade compatibility for older clients on ordinary scoped
+        // calls. `scope_allowed` keeps this credential off proxy routes.
+        Some(AuthScope::Host)
+    } else {
+        None
+    }
+}
+
+fn authorize(state: &State, request: &Request, segments: &[&str]) -> Option<AuthScope> {
+    if !state.host_mode {
+        return host_token_matches(state, request).then_some(AuthScope::Host);
+    }
+
+    match segments {
+        // Pool lifecycle and token recovery are host-management operations.
+        ["v1", "sandboxes"] | ["v1", "sandboxes", _, "token"] => {
+            host_token_matches(state, request).then_some(AuthScope::Host)
+        }
+        ["v1", "sandboxes", id, ..] => {
+            let provided = request.header("x-sandbox-token")?;
+            let entry = state.sandboxes.get(id)?;
+            classify_scoped_token(provided, &entry.token, state.token.as_deref())
+        }
+        _ => None,
+    }
+}
+
+fn scope_allowed(auth_scope: AuthScope, segments: &[&str]) -> bool {
+    auth_scope != AuthScope::Host || !matches!(segments, ["v1", "sandboxes", _, "proxy", ..])
+}
+
+fn route_mode_allowed(host_mode: bool, segments: &[&str]) -> bool {
+    let host_scoped = matches!(segments, ["v1", "sandboxes", ..]);
+    host_mode == host_scoped
 }
 
 fn route(
@@ -81,12 +131,18 @@ fn route(
         );
     }
 
-    if !authorized(state, request) {
+    let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
+    if !route_mode_allowed(state.host_mode, &segments) {
+        return resp.error(404, &format!("no route in this server mode: {method} {path}"));
+    }
+    let Some(auth_scope) = authorize(state, request, &segments) else {
         return resp.error(403, "invalid or missing X-Sandbox-Token");
+    };
+    if state.host_mode && !scope_allowed(auth_scope, &segments) {
+        return resp.error(403, "host-management tokens cannot access sandbox proxy routes");
     }
     state.last_activity_ms.store(now_ms(), Ordering::Relaxed);
 
-    let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
     // Per-sandbox activity (host-mode idle eviction): any request scoped to a sandbox
     // resets its idle timer.
     if let ["v1", "sandboxes", id, ..] = segments.as_slice() {
@@ -113,6 +169,10 @@ fn route(
             let id = id.to_string();
             sandboxes::handle_delete(state, &id, resp)
         }
+        ("GET", ["v1", "sandboxes", id, "token"]) => match state.sandboxes.get(id) {
+            Some(entry) => resp.json(200, &serde_json::json!({"id": id, "token": entry.token})),
+            None => resp.error(404, &format!("no such sandbox: {id}")),
+        },
         // Per-sandbox operations mirror the dedicated routes, scoped to one sandbox
         // (its uid, its home, its processes). The client uses the same surface for
         // both modes, only the URL prefix differs.
@@ -197,6 +257,10 @@ fn main() {
     let capacity = std::env::var("SBX_CAPACITY").ok().and_then(|v| v.parse().ok()).unwrap_or(usize::MAX);
     // Host mode multiplexes many sandboxes; dedicated mode is one sandbox == the job.
     let host_mode = std::env::var("SBX_HOST_MODE").map(|v| v == "1").unwrap_or(false);
+    if host_mode && token.is_none() {
+        eprintln!("sbx-server: SBX_TOKEN is required in host mode");
+        std::process::exit(1);
+    }
 
     let state = Arc::new(State {
         token,
@@ -266,5 +330,33 @@ fn main() {
         let Ok(stream) = stream else { continue };
         let state = Arc::clone(&state);
         std::thread::spawn(move || handle_connection(state, stream));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routes_are_exclusive_to_the_configured_mode() {
+        assert!(route_mode_allowed(false, &["v1", "exec"]));
+        assert!(route_mode_allowed(false, &["v1", "proxy", "8000"]));
+        assert!(!route_mode_allowed(false, &["v1", "sandboxes"]));
+
+        assert!(route_mode_allowed(true, &["v1", "sandboxes"]));
+        assert!(route_mode_allowed(true, &["v1", "sandboxes", "id", "exec"]));
+        assert!(!route_mode_allowed(true, &["v1", "exec"]));
+        assert!(!route_mode_allowed(true, &["v1", "proxy", "8000"]));
+    }
+
+    #[test]
+    fn pooled_tokens_are_scoped_and_host_tokens_cannot_proxy() {
+        assert_eq!(classify_scoped_token("sandbox-a", "sandbox-a", Some("host")), Some(AuthScope::Sandbox));
+        assert_eq!(classify_scoped_token("host", "sandbox-a", Some("host")), Some(AuthScope::Host));
+        assert_eq!(classify_scoped_token("sandbox-b", "sandbox-a", Some("host")), None);
+
+        assert!(scope_allowed(AuthScope::Sandbox, &["v1", "sandboxes", "a", "proxy", "8000"]));
+        assert!(!scope_allowed(AuthScope::Host, &["v1", "sandboxes", "a", "proxy", "8000"]));
+        assert!(scope_allowed(AuthScope::Host, &["v1", "sandboxes", "a", "exec"]));
     }
 }

--- a/src/sandboxes.rs
+++ b/src/sandboxes.rs
@@ -14,7 +14,7 @@ use std::io::{BufReader, Read};
 use std::net::TcpStream;
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::PermissionsExt;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicI64, AtomicU32, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -35,6 +35,8 @@ const DEFAULT_MAX_MEM_MB: u64 = 2048; // RLIMIT_AS, per process
 
 pub struct SandboxEntry {
     pub id: String,
+    /// Capability token accepted for this sandbox's scoped routes.
+    pub token: String,
     pub uid: u32,
     pub home: String,
     pub created_at_ms: i64,
@@ -66,14 +68,10 @@ pub struct SandboxRegistry {
     reserved: AtomicUsize,
 }
 
-fn random_id() -> String {
-    let mut buf = [0u8; 8];
-    if std::fs::File::open("/dev/urandom").and_then(|mut f| f.read_exact(&mut buf)).is_err() {
-        // /dev/urandom always exists on Linux; fallback just in case
-        let t = now_ms() as u64;
-        buf.copy_from_slice(&t.to_le_bytes());
-    }
-    buf.iter().map(|b| format!("{b:02x}")).collect()
+fn random_hex<const N: usize>() -> std::io::Result<String> {
+    let mut buf = [0u8; N];
+    std::fs::File::open("/dev/urandom")?.read_exact(&mut buf)?;
+    Ok(buf.iter().map(|b| format!("{b:02x}")).collect())
 }
 
 impl SandboxRegistry {
@@ -120,7 +118,8 @@ impl SandboxRegistry {
                 format!("sandbox uid pool exhausted (max {} concurrent sandboxes per host)", UID_MAX - UID_BASE),
             ));
         }
-        let id = random_id();
+        let id = random_hex::<8>()?;
+        let token = random_hex::<32>()?;
         let home = format!("{HOMES_DIR}/{id}");
         std::fs::create_dir_all(&home)?;
         std::fs::set_permissions(&home, std::fs::Permissions::from_mode(0o700))?;
@@ -128,19 +127,18 @@ impl SandboxRegistry {
         std::fs::create_dir_all(&tmp)?;
         // Where the sandbox binds the unix sockets it wants exposed via the port proxy
         // (it can't bind TCP under Landlock). Surfaced as $SBX_PROXY_DIR; see proxy.rs.
+        let sbx_dir = format!("{home}/.sbx");
         let proxy_dir = format!("{home}/{}", crate::proxy::PROXY_SUBDIR);
         std::fs::create_dir_all(&proxy_dir)?;
-        unsafe {
-            let c_home = std::ffi::CString::new(home.as_str()).unwrap();
-            let c_tmp = std::ffi::CString::new(tmp.as_str()).unwrap();
-            libc::chown(c_home.as_ptr(), uid, uid);
-            libc::chown(c_tmp.as_ptr(), uid, uid);
+        // Nothing untrusted can run until the entry is registered. Assign the
+        // initial tree without ever following a link.
+        for path in [&home, &tmp, &sbx_dir, &proxy_dir] {
+            chown_no_follow(Path::new(path), uid)?;
         }
-        // chown the .sbx/proxy chain so the sandbox uid can create sockets in it.
-        chown_into_home(&home, Path::new(&proxy_dir), uid);
         let landlock_fd = crate::landlock::build_ruleset(&home).unwrap_or(-1);
         let entry = Arc::new(SandboxEntry {
             id: id.clone(),
+            token,
             uid,
             home,
             created_at_ms: now_ms(),
@@ -301,57 +299,13 @@ pub fn base_env(entry: &SandboxEntry) -> Vec<(String, String)> {
     env
 }
 
-// ---------------------------------------------------------------------------
-// Per-sandbox filesystem helpers
-// ---------------------------------------------------------------------------
-
-/// Resolve a user-facing path to an absolute path confined to the sandbox home.
-///
-/// In host mode a sandbox's writable view is its home (Landlock confines the
-/// running code to it), so the file API roots every path at the home: a path is
-/// taken relative to the home (a leading `/` is ignored) and `..` components can
-/// never climb above it. This gives the caller a clean "filesystem rooted at the
-/// sandbox" model that matches what code running inside the sandbox can touch.
-pub fn resolve_in_home(home: &str, path: &str) -> PathBuf {
-    let mut stack: Vec<std::ffi::OsString> = Vec::new();
-    for comp in Path::new(path).components() {
-        match comp {
-            Component::Normal(c) => stack.push(c.to_os_string()),
-            Component::ParentDir => {
-                stack.pop();
-            }
-            // RootDir / CurDir / Prefix are dropped: everything is relative to home.
-            _ => {}
-        }
-    }
-    let mut result = PathBuf::from(home);
-    for c in stack {
-        result.push(c);
-    }
-    result
-}
-
-fn chown(path: &Path, uid: u32) {
-    if let Ok(c) = CString::new(path.as_os_str().as_bytes()) {
-        unsafe {
-            libc::chown(c.as_ptr(), uid, uid);
-        }
-    }
-}
-
-/// Chown `target` and every ancestor up to (but excluding) `home` to `uid`, so
-/// files placed through the API are owned by the sandbox and readable/writable
-/// by its code (which runs as `uid`). Anything created as root would otherwise
-/// be inaccessible to the sandbox.
-pub fn chown_into_home(home: &str, target: &Path, uid: u32) {
-    let home_path = Path::new(home);
-    let mut cur = Some(target);
-    while let Some(p) = cur {
-        if p == home_path || !p.starts_with(home_path) {
-            break;
-        }
-        chown(p, uid);
-        cur = p.parent();
+fn chown_no_follow(path: &Path, uid: u32) -> std::io::Result<()> {
+    let path = CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "path contains NUL"))?;
+    if unsafe { libc::lchown(path.as_ptr(), uid, uid) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
     }
 }
 
@@ -379,7 +333,12 @@ pub fn handle_create(
     let mut rejected = 0usize;
     for _ in 0..count {
         match state.sandboxes.create(env.clone(), max_procs, max_mem_mb, idle_timeout_ms) {
-            Ok(entry) => created.push(serde_json::json!({"id": entry.id, "uid": entry.uid, "home": entry.home})),
+            Ok(entry) => created.push(serde_json::json!({
+                "id": entry.id,
+                "token": entry.token,
+                "uid": entry.uid,
+                "home": entry.home,
+            })),
             // Host full: report how many we couldn't place so the client packs them
             // onto another host (or boots a duplicate). Not an error.
             Err(CreateError::Full) => {


### PR DESCRIPTION
## Related to https://huggingface.slack.com/archives/C03Q18WK18T/p1788160539575999, let's see what we want to do first

## Summary

- resolve pooled file API paths component-by-component from an open sandbox home descriptor, never following symlinks or performing path-based ownership changes
- mint a random capability for each pooled sandbox and reserve the host credential for management; the rolling-upgrade compatibility path is explicitly rejected for pooled proxy requests
- make host and dedicated route surfaces mutually exclusive, require authentication in host mode, and add scoped token recovery for stateless reconnect
- bump sbx-server to 0.6.0 and document the revised protocol

## Rollout

Deploy this server before the companion huggingface_hub change. Existing clients keep working for non-proxy scoped calls, while pooled proxy calls require the upgraded client. Existing pool host jobs must be recycled after publishing the new bucket binary; otherwise they keep running the old process.

Companion client PR: https://github.com/huggingface/huggingface_hub/pull/4782

## Validation

- cargo test
- cargo build --release
- cargo clippy --all-targets (three pre-existing style warnings)
- live root container regression covering final/intermediate symlink read and write attempts, sibling ownership, cross-sandbox credentials, host proxy credentials, and unscoped host routes